### PR TITLE
Add props which allow custom styling for button and "selected" button

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -421,7 +421,7 @@ ReversedRadioButton.propTypes = {
   horizontal: _propTypes2.default.bool,
   onChange: _propTypes2.default.func,
   disabled: _propTypes2.default.bool,
-  disabledColor: _propTypes2.default.bool,
+  disabledColor: _propTypes2.default.string,
   label: _propTypes2.default.string
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -234,7 +234,7 @@ var RadioButton = exports.RadioButton = function (_Component2) {
           label = _props6.label;
 
       var style = this.getStyles();
-      var buttonStyle = Object.assign({}, style.root, checked ? style.checked, pointStyling : {}, buttonStyling);
+      var buttonStyle = Object.assign({}, style.root, checked ? style.checked : {}, checked ? pointStyling : buttonStyling) 
       var labelStyle = Object.assign({}, style.root, style.label);
 
       return _react2.default.createElement(
@@ -374,7 +374,7 @@ var ReversedRadioButton = exports.ReversedRadioButton = function (_Component3) {
           label = _props9.label;
 
       var style = this.getStyles();
-      var buttonStyle = Object.assign({}, style.root, checked ? style.checked, pointStyling : {}, buttonStyling);
+      var buttonStyle = Object.assign({}, style.root, checked ? style.checked : {}, checked ? pointStyling : buttonStyling) 
       var labelStyle = Object.assign({}, style.root, style.label);
 
       return _react2.default.createElement(

--- a/lib/index.js
+++ b/lib/index.js
@@ -224,6 +224,7 @@ var RadioButton = exports.RadioButton = function (_Component2) {
           checked = _props6.checked,
           iconSize = _props6.iconSize,
           buttonStyling = _props6.buttonStyling,
+          pointStyling = _props6.pointStyling,
           iconInnerSize = _props6.iconInnerSize,
           rootColor = _props6.rootColor,
           pointColor = _props6.pointColor,
@@ -233,7 +234,7 @@ var RadioButton = exports.RadioButton = function (_Component2) {
           label = _props6.label;
 
       var style = this.getStyles();
-      var buttonStyle = Object.assign({}, style.root, checked ? style.checked : {}, buttonStyling);
+      var buttonStyle = Object.assign({}, style.root, checked ? style.checked, pointStyling : {}, buttonStyling);
       var labelStyle = Object.assign({}, style.root, style.label);
 
       return _react2.default.createElement(
@@ -281,6 +282,7 @@ RadioButton.propTypes = {
   value: _propTypes2.default.string,
   index: _propTypes2.default.number,
   buttonStyling: _propTypes2.default.object,
+  pointStyling: _propTypes2.default.object,
   checked: _propTypes2.default.bool,
   children: _propTypes2.default.node,
   horizontal: _propTypes2.default.bool,
@@ -360,6 +362,7 @@ var ReversedRadioButton = exports.ReversedRadioButton = function (_Component3) {
       var _props9 = this.props,
           checked = _props9.checked,
           buttonStyling = _props9.buttonStyling,
+          pointStyling = _props9.pointStyling,
           iconSize = _props9.iconSize,
           iconInnerSize = _props9.iconInnerSize,
           rootColor = _props9.rootColor,
@@ -371,7 +374,7 @@ var ReversedRadioButton = exports.ReversedRadioButton = function (_Component3) {
           label = _props9.label;
 
       var style = this.getStyles();
-      var buttonStyle = Object.assign({}, style.root, checked ? style.checked : {}, buttonStyling);
+      var buttonStyle = Object.assign({}, style.root, checked ? style.checked, pointStyling : {}, buttonStyling);
       var labelStyle = Object.assign({}, style.root, style.label);
 
       return _react2.default.createElement(
@@ -419,6 +422,7 @@ ReversedRadioButton.propTypes = {
   pointColor: _propTypes2.default.string,
   value: _propTypes2.default.string,
   buttonStyling: _propTypes2.default.object,
+  pointStyling: _propTypes2.default.object,
   index: _propTypes2.default.number,
   checked: _propTypes2.default.bool,
   children: _propTypes2.default.node,

--- a/lib/index.js
+++ b/lib/index.js
@@ -223,6 +223,7 @@ var RadioButton = exports.RadioButton = function (_Component2) {
       var _props6 = this.props,
           checked = _props6.checked,
           iconSize = _props6.iconSize,
+          buttonStyling = _props6.buttonStyling,
           iconInnerSize = _props6.iconInnerSize,
           rootColor = _props6.rootColor,
           pointColor = _props6.pointColor,
@@ -232,7 +233,7 @@ var RadioButton = exports.RadioButton = function (_Component2) {
           label = _props6.label;
 
       var style = this.getStyles();
-      var buttonStyle = Object.assign({}, style.root, checked ? style.checked : {});
+      var buttonStyle = Object.assign({}, style.root, checked ? style.checked : {}, buttonStyling);
       var labelStyle = Object.assign({}, style.root, style.label);
 
       return _react2.default.createElement(
@@ -279,6 +280,7 @@ RadioButton.propTypes = {
   pointColor: _propTypes2.default.string,
   value: _propTypes2.default.string,
   index: _propTypes2.default.number,
+  buttonStyling: _propTypes2.default.object,
   checked: _propTypes2.default.bool,
   children: _propTypes2.default.node,
   horizontal: _propTypes2.default.bool,
@@ -357,6 +359,7 @@ var ReversedRadioButton = exports.ReversedRadioButton = function (_Component3) {
     value: function render() {
       var _props9 = this.props,
           checked = _props9.checked,
+          buttonStyling = _props9.buttonStyling,
           iconSize = _props9.iconSize,
           iconInnerSize = _props9.iconInnerSize,
           rootColor = _props9.rootColor,
@@ -368,7 +371,7 @@ var ReversedRadioButton = exports.ReversedRadioButton = function (_Component3) {
           label = _props9.label;
 
       var style = this.getStyles();
-      var buttonStyle = Object.assign({}, style.root, checked ? style.checked : {});
+      var buttonStyle = Object.assign({}, style.root, checked ? style.checked : {}, buttonStyling);
       var labelStyle = Object.assign({}, style.root, style.label);
 
       return _react2.default.createElement(
@@ -415,6 +418,7 @@ ReversedRadioButton.propTypes = {
   rootColor: _propTypes2.default.string,
   pointColor: _propTypes2.default.string,
   value: _propTypes2.default.string,
+  buttonStyling: _propTypes2.default.object,
   index: _propTypes2.default.number,
   checked: _propTypes2.default.bool,
   children: _propTypes2.default.node,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-radio-buttons",
+  "name": "@lionel-lints/react-radio-buttons",
   "version": "1.2.0",
   "description": "Well-designed radio buttons for react.",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@lionel-lints/react-radio-buttons",
+  "name": "react-radio-buttons",
   "version": "1.2.0",
   "description": "Well-designed radio buttons for react.",
   "main": "lib/index.js",


### PR DESCRIPTION
This is a small PR to allow for custom styling to be added so css classes can overwrite the specific styles as needed. I am not sure this is the best solution, but the base case works for me. Happy to update anything upon request as well :-)

A developer could then add a `buttonStyling` prop and a `pointStyling` prop to the component which would overwrite any css as needed for both selected and unselected cases.

Added styling to adjust the css for the icon is not provided in this PR, I could potentially do it though in the future.

